### PR TITLE
Secret update

### DIFF
--- a/controllers/scripts/ipfs.go
+++ b/controllers/scripts/ipfs.go
@@ -55,8 +55,8 @@ if [[ -f /data/ipfs/config ]]; then
 fi
 
 echo '{{ .FlattenedConfig }}' > config.json
-sed -i s/_peer-id_/"${PEER_ID}"/g
-sed -i s/_private-key_/"${PRIVATE_KEY}"/g
+sed -i s,_peer-id_,"${PEER_ID}",g config.json
+sed -i s,_private-key_,"${PRIVATE_KEY}",g config.json
 
 ipfs init -- config.json
 

--- a/controllers/secret.go
+++ b/controllers/secret.go
@@ -45,6 +45,7 @@ func (r *IpfsReconciler) secretConfig(
 	if err != nil && errors.IsNotFound(err) {
 		// secret doesn't exist
 		generateNewIdentities(expectedSecret, 0, m.Spec.Replicas)
+		expectedSecret.Data = make(map[string][]byte)
 		expectedSecret.Data["CLUSTER_SECRET"] = clusterSecret
 		expectedSecret.Data["BOOTSTRAP_PEER_PRIV_KEY"] = bootstrapPrivateKey
 	}
@@ -85,6 +86,7 @@ func countIdentities(secret *corev1.Secret) int32 {
 // generateNewIdentities Populates the secret data with new Peer IDs
 // and private keys which are mapped based on the replica number.
 func generateNewIdentities(secret *corev1.Secret, start, n int32) error {
+	secret.StringData = make(map[string]string)
 	for i := start; i < n; i++ {
 		// generate new private key & peer id
 		peerID, privKey, err := generateIdentity()


### PR DESCRIPTION
Instantiate maps so we can assign values.

updates sed lines. Uses commas rather than the traditional forward slash because slashes are part of base64 and commas are not.